### PR TITLE
Do not touch load_path

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -20,7 +20,6 @@ Rake::TestTask.new(:dummytest_controller) { |t| t.pattern = 'spec/fixtures/dummy
 
 task default: :spec
 
-$LOAD_PATH.push File.expand_path('lib', __dir__)
 require 'routes_coverage/version'
 
 namespace :assets do

--- a/routes_coverage.gemspec
+++ b/routes_coverage.gemspec
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-lib = File.expand_path('lib', __dir__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'routes_coverage/version'
+require_relative './lib/routes_coverage/version'
 
 Gem::Specification.new do |spec|
   spec.name          = "routes_coverage"
@@ -16,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/Vasfed/routes_coverage"
   spec.license       = "MIT"
 
-  spec.required_ruby_version = ">= 1.9"
+  spec.required_ruby_version = ">= 1.9.2"
 
   spec.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features|assets|bin|gemfiles)/}) ||


### PR DESCRIPTION
not needed (bundler does it for us)
also ruby >= 1.9.2 has `require_relative`